### PR TITLE
Raise android-port-test minSdk to 23

### DIFF
--- a/android-port-test/build.gradle
+++ b/android-port-test/build.gradle
@@ -8,7 +8,7 @@ android {
 
     defaultConfig {
         applicationId "com.jasonernst.porttest"
-        minSdkVersion 21
+        minSdkVersion 23
         targetSdkVersion 34
         versionCode 1
         versionName "1.0"


### PR DESCRIPTION
Renovate PR #149 (appcompat 1.7.1 → 1.8.0) fails CI:

```
Manifest merger failed : uses-sdk:minSdkVersion 21 cannot be smaller than
version 23 declared in library [androidx.appcompat:appcompat-resources:1.8.0]
```

appcompat 1.8.0 requires minSdk 23. `android-ping-test` is already at 23; this
brings `android-port-test` in line. Verified locally: with minSdk 23 + appcompat
1.8.0, `:android-port-test:assembleDebug` succeeds.

Once this merges, #149 should pass on rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)